### PR TITLE
impl: Iterate through cards

### DIFF
--- a/frontend/flashfolio/src/Viewer.js
+++ b/frontend/flashfolio/src/Viewer.js
@@ -1,4 +1,4 @@
-import React, {useState, useEffect} from "react";
+import React, {useState, useEffect, useRef} from "react";
 import {useParams} from "react-router-dom";
 import Flashcard from "./Flashcard";
 
@@ -11,9 +11,11 @@ Displays a single card at a time to the screen.
 */
 export default function Viewer() {
 
-	let flashdeck = "";
+	const flashdeck = useRef("");
+	const isInitialMount = useRef(true);
 
 	const [flashcard, setFlashcard] = useState("");
+	const [cardIterator, setCardIterator] = useState(0);
 
 	let { deckId } = useParams();
 
@@ -34,15 +36,31 @@ export default function Viewer() {
 					/* Update the deck to reflect what is on the server 
 					   Warning is ignored as this Effect is only triggered once */
 					// eslint-disable-next-line
-					flashdeck = data;
-					setFlashcard(flashdeck.Cards[0]);
+					flashdeck.current = data;
+					setFlashcard(flashdeck.current.Cards[0]);
 				});
-	}, [])
+	}, []);
+
+	useEffect(() => {
+		if (isInitialMount.current) {
+			isInitialMount.current = false;
+		} 
+		else {
+			 // useEffect code here to be run on count update only
+			if(cardIterator < flashdeck.current.Cards.length) {
+				setFlashcard(flashdeck.current.Cards[cardIterator]);
+			}
+			else { setCardIterator(0); }
+		}
+	}, [cardIterator])
 
 	return (
 		<div>
 		CardId: {deckId}
 		<Flashcard flashcard={flashcard} />
+		<button
+			onClick={() => setCardIterator(cardIterator + 1)}
+			>Next Card</button>
 		</div>
 	);
 }


### PR DESCRIPTION
Add the ability to view the next card by clicking on a button. Once the end of the deck is reached,
the deck will cycle and show the first card again.
Overview of Changes (All changes are made in Viewer.js):
        1. Add useRef hook to reference the deck.
        2. Add useState hook to iterate through cards.
        3. Add useRef hook to keep track of whether the current mount is the initial one.
        4. Add useEffect to iterate through deck and cycle through when reaching the end.
        5. Add button and onClick event to create changes (when button is clicked, next card is shown).
Closes issue #10