### PR TITLE
impl: Editing Cards & Card Editor

### DIFF
--- a/frontend/flashfolio/src/App.js
+++ b/frontend/flashfolio/src/App.js
@@ -17,6 +17,9 @@ function App() {
 			<Route path="/view/:deckId">
 				<Viewer />
 			</Route>
+			<Route path="/edit/:deckId">
+				<Viewer viewMode="edit"/>
+			</Route>
 			<Route path="/">
 				<Home />
 			</Route>

--- a/frontend/flashfolio/src/Flashcard.css
+++ b/frontend/flashfolio/src/Flashcard.css
@@ -3,13 +3,23 @@
 visual styling for the flashcard
 */
 .card {
-	border:1px;
-	border-style:solid;
-	height:200px;
-	width:500px;
+	border: 1px;
+	border-style: solid;
+	height: 200px;
+	width: 500px;
 
 	/* Center Text */
 	display: grid;
 	place-items: center;
 }
+
+/*
+For the text area of the card editor
+*/
+.cardEditor {
+	height: 90%;
+	width: 90%;
+	resize: none;
+}
+
 

--- a/frontend/flashfolio/src/Flashcard.js
+++ b/frontend/flashfolio/src/Flashcard.js
@@ -1,11 +1,45 @@
-import React, {useState} from 'react'
+import React, {useState, useRef, useEffect} from 'react'
 import './Flashcard.css'
 
-export default function Flashcard({flashcard}) {
+export default function Flashcard({flashcard, editMode=false}) {
+
 	const [flip, setFlip] = useState(false);
+	const [showEditor, setShowEditor] = useState(false);	
+
+	const currentSide = () => flip ? flashcard.BackSide : flashcard.FrontSide;
+
+	const editor = useRef(null);
+
+	const updateCard = () => {
+		if (flip) {
+			flashcard.BackSide = editor.current.value;
+		} else {
+			flashcard.FrontSide = editor.current.value;
+		}
+	}
+
+	const cardContents = () => {
+		if (!editMode || !showEditor) {
+			return currentSide();
+		} else {
+			return (
+				<textarea className="cardEditor" onChange={updateCard}
+					defaultValue={currentSide()} ref={editor}/>
+			)
+		}
+	}
+
+	const cardClick = () => !editMode || !showEditor ? setFlip(!flip) : "";
+
 	return (
-		<div onClick={() => setFlip(!flip)} class="card">
-			{flip ? flashcard.BackSide : flashcard.FrontSide}	
+		<div>
+		{editMode ? 
+			<button onClick={()=>{setShowEditor(!showEditor)}}>
+				{showEditor ? "Done" : "Edit Card"} 
+			</button>:""}
+		<div onClick={cardClick} class="card">
+			{cardContents()}
+		</div>
 		</div>
 	)
 }

--- a/frontend/flashfolio/src/Flashcard.js
+++ b/frontend/flashfolio/src/Flashcard.js
@@ -6,14 +6,20 @@ export default function Flashcard({flashcard, editMode=false}) {
 	const [flip, setFlip] = useState(false);
 	const [showEditor, setShowEditor] = useState(false);	
 
+	/* Returns appropriate side according to flip state */
 	const currentSide = () => flip ? flashcard.BackSide : flashcard.FrontSide;
 
+	/* Ref for the actual textarea (maybe can be removed?)*/
 	const editor = useRef(null);
+
+	/* State for the editor textarea's value */
 	const [editVal, setEditVal] = useState("");
 
+	/* Executed when editor textarea is changed by user */
 	const updateCard = () => {
-		console.log("updated!!!");
+		/* update editVal to reflect changes */
 		setEditVal(editor.current.value);
+		/* update actual card to reflect changes */
 		if (flip) {
 			flashcard.BackSide = editor.current.value;
 		} else {
@@ -21,10 +27,12 @@ export default function Flashcard({flashcard, editMode=false}) {
 		}
 	}
 
+	/* Gets the card divs current contents (View/Edit Mode) */
 	const cardContents = () => {
 		if (!editMode || !showEditor) {
 			return currentSide();
 		} else {
+			/* Place edit mode editor */
 			return (
 				<textarea className="cardEditor" onChange={updateCard}
 					value={editVal} ref={editor} />
@@ -32,6 +40,7 @@ export default function Flashcard({flashcard, editMode=false}) {
 		}
 	}
 
+	/* flip the card */
 	const flipCard = () => {
 		/* This is very ugly and will need to be cleaned up */
 		if (showEditor) {
@@ -40,8 +49,10 @@ export default function Flashcard({flashcard, editMode=false}) {
 		setFlip(!flip)
 	}
 
+	/* If in edit mode, do nothing when card clicked */
 	const cardClick = () => !editMode || !showEditor ? flipCard() : "";
 
+	/* Show card editor */
 	const editCard = () => {
 		if (!showEditor) {
 			setEditVal(currentSide());

--- a/frontend/flashfolio/src/Flashcard.js
+++ b/frontend/flashfolio/src/Flashcard.js
@@ -9,8 +9,11 @@ export default function Flashcard({flashcard, editMode=false}) {
 	const currentSide = () => flip ? flashcard.BackSide : flashcard.FrontSide;
 
 	const editor = useRef(null);
+	const [editVal, setEditVal] = useState("");
 
 	const updateCard = () => {
+		console.log("updated!!!");
+		setEditVal(editor.current.value);
 		if (flip) {
 			flashcard.BackSide = editor.current.value;
 		} else {
@@ -24,21 +27,37 @@ export default function Flashcard({flashcard, editMode=false}) {
 		} else {
 			return (
 				<textarea className="cardEditor" onChange={updateCard}
-					defaultValue={currentSide()} ref={editor} />
+					value={editVal} ref={editor} />
 			)
 		}
 	}
 
 	const flipCard = () => {
+		/* This is very ugly and will need to be cleaned up */
+		if (showEditor) {
+			setEditVal(!flip ? flashcard.BackSide : flashcard.FrontSide);
+		}
 		setFlip(!flip)
 	}
 
 	const cardClick = () => !editMode || !showEditor ? flipCard() : "";
 
+	const editCard = () => {
+		if (!showEditor) {
+			setEditVal(currentSide());
+		}
+		setShowEditor(!showEditor);
+	}
+
+	/* If the flashcard changes to a different one, update the editor */
+	useEffect(() => {
+		setEditVal(currentSide());
+	}, [flashcard]);
+
 	return (
 		<div>
 		{editMode ? 
-			<button onClick={()=>{setShowEditor(!showEditor)}}>
+			<button onClick={editCard}>
 				{showEditor ? "Done" : "Edit Card"} 
 			</button>:""}
 		<button onClick={flipCard}>

--- a/frontend/flashfolio/src/Flashcard.js
+++ b/frontend/flashfolio/src/Flashcard.js
@@ -24,12 +24,16 @@ export default function Flashcard({flashcard, editMode=false}) {
 		} else {
 			return (
 				<textarea className="cardEditor" onChange={updateCard}
-					defaultValue={currentSide()} ref={editor}/>
+					defaultValue={currentSide()} ref={editor} />
 			)
 		}
 	}
 
-	const cardClick = () => !editMode || !showEditor ? setFlip(!flip) : "";
+	const flipCard = () => {
+		setFlip(!flip)
+	}
+
+	const cardClick = () => !editMode || !showEditor ? flipCard() : "";
 
 	return (
 		<div>
@@ -37,6 +41,9 @@ export default function Flashcard({flashcard, editMode=false}) {
 			<button onClick={()=>{setShowEditor(!showEditor)}}>
 				{showEditor ? "Done" : "Edit Card"} 
 			</button>:""}
+		<button onClick={flipCard}>
+			Flip
+		</button>
 		<div onClick={cardClick} class="card">
 			{cardContents()}
 		</div>

--- a/frontend/flashfolio/src/Viewer.js
+++ b/frontend/flashfolio/src/Viewer.js
@@ -45,7 +45,7 @@ export default function Viewer({viewMode="view"}) {
 			isInitialMount.current = false;
 		} 
 		else {
-			 // useEffect code here to be run on count update only
+			/* useEffect code here to be run on count update only */
 			if(cardIterator < flashdeck.current.Cards.length) {
 				setFlashcard(flashdeck.current.Cards[cardIterator]);
 			}

--- a/frontend/flashfolio/src/Viewer.js
+++ b/frontend/flashfolio/src/Viewer.js
@@ -2,14 +2,13 @@ import React, {useState, useEffect, useRef} from "react";
 import {useParams} from "react-router-dom";
 import Flashcard from "./Flashcard";
 
-
 /*
 Viewer
 
 Grabs a deck from the backend.
 Displays a single card at a time to the screen.
 */
-export default function Viewer() {
+export default function Viewer({viewMode="view"}) {
 
 	const flashdeck = useRef("");
 	const isInitialMount = useRef(true);
@@ -57,7 +56,7 @@ export default function Viewer() {
 	return (
 		<div>
 		CardId: {deckId}
-		<Flashcard flashcard={flashcard} />
+		<Flashcard flashcard={flashcard} editMode={viewMode == "edit"} />
 		<button
 			onClick={() => setCardIterator(cardIterator + 1)}
 			>Next Card</button>


### PR DESCRIPTION
This implements a basic card editor, which allows the user to visit the /edit/:id directory to edit the cards of a given deck.

Overview of changes:

1. Created /edit/:id route in router
2. Added a `viewMode` prop in the Viewer component. It controls whether the user is editing or just viewing a deck.
3. Added an `editMode` prop in the Flashcard that controls whether a given card instance is being edited or not.
4. Added a textArea as the editor w/ associated Ref & State.
5. Added a discrete flip button.
6. Added an enter/exit edit mode button.
7. Added a new Effect which will actually re-render the flashcard when the flashcard prop is changed.

closes #18 