### PR TITLE
impl:add download feature

### DIFF
--- a/frontend/flashfolio/src/Viewer.js
+++ b/frontend/flashfolio/src/Viewer.js
@@ -60,6 +60,12 @@ export default function Viewer({viewMode="view"}) {
 		<button
 			onClick={() => setCardIterator(cardIterator + 1)}
 			>Next Card</button>
+		<a
+            href={`data:text/json;charset=utf-8,${encodeURIComponent(
+              JSON.stringify(flashdeck.current, null, '\t')
+            )}`}
+            download="myDeck.json"
+          >{`Download`}</a>
 		</div>
 	);
 }


### PR DESCRIPTION
issue #28 

- Deck data can be downloaded as a .json
- The code is written to download just the variable flashdeck.current from Viewer.js

Downloading decks is a practical feature to have for development testing and for users to backup their data