### PR TITLE
fix: Fixed a bug that added extra components to flashcard

### DIFF
--- a/frontend/flashfolio/src/Viewer.js
+++ b/frontend/flashfolio/src/Viewer.js
@@ -101,7 +101,7 @@ export default function Viewer({ viewMode = "view" }) {
 	}, [cardIterator])
 
 	function addCard() {
-		flashdeck.current.Cards[flashdeck.current.Cards.length] = {frontSide: "new", backSide: "null"};
+		flashdeck.current.Cards[flashdeck.current.Cards.length] = {FrontSide: "", BackSide: ""};
 		setCardIterator(flashdeck.current.Cards.length-1);
 		setFlashcard(flashdeck.current.Cards[cardIterator]);
 	}


### PR DESCRIPTION
Overview of changes:
1. Changed "frontSide" to "FrontSide" and "backSide" to "BackSide" in the addCard() function of Viewer.js.
2. Made it so an empty string would be the values of "FrontSide" and "BackSide".

closes #49 