### PR TITLE
impl: Added button to change between edit and view mode

### DIFF
--- a/frontend/flashfolio/src/Viewer.js
+++ b/frontend/flashfolio/src/Viewer.js
@@ -156,7 +156,7 @@ export default function Viewer({ viewMode = "view" }) {
 			Title: {flashdeck.current.Title}
 			DeckId: {deckId}
 			<br />
-			<button onClick = {flipView}> {viewMode == "edit" ? <a>View Deck</a> : <a>Edit Deck</a>} </button>
+			<button onClick = {flipView}> {viewMode == "edit" ? "View Deck" : "Edit Deck"} </button>
 			{viewMode == "edit" && <button onClick={changeLayout}>Change Layout</button>}
 			{tileLayout()}
 			{!tileCards && <button

--- a/frontend/flashfolio/src/Viewer.js
+++ b/frontend/flashfolio/src/Viewer.js
@@ -27,6 +27,17 @@ export default function Viewer({ viewMode = "view" }) {
 
 	const [tileCards, setTileCards] = useState(false);
 
+	function flipView(){
+		if(viewMode==="view")
+			history.replace("/edit/"+deckId);
+		else
+		{
+			if(tileCards)
+				setTileCards(false);
+			history.replace("/view/"+deckId);
+		}
+	}
+
 	function shufFunction() {
 		hidden = false;
 		setCardIterator(0);
@@ -145,6 +156,7 @@ export default function Viewer({ viewMode = "view" }) {
 			Title: {flashdeck.current.Title}
 			DeckId: {deckId}
 			<br />
+			<button onClick = {flipView}> {viewMode == "edit" ? <a>View Deck</a> : <a>Edit Deck</a>} </button>
 			{viewMode == "edit" && <button onClick={changeLayout}>Change Layout</button>}
 			{tileLayout()}
 			{!tileCards && <button


### PR DESCRIPTION
Added a button that allows for one to switch to edit mode from view mode, and vice versa.

Overview of changes:
1. Added a button that will display the text "Edit Deck" if in view mode, or "View Deck" if in edit mode. On click, will call the added function "flipView()"
2. Added a function "flipView()" that will change the url path to "/edit/"+deckId if in view mode, or to "/view/"+deckId if in edit mode.
3. Additionally, if switching from edit mode to view mode, if the layout is in tile format, the format will be swapped back to the normal layout before switching.

closes #59 