### PR TITLE
impl: Deck privacy

### DIFF
--- a/backend/flashfolio/main.go
+++ b/backend/flashfolio/main.go
@@ -113,7 +113,8 @@ func getDeckReq(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var req struct {
-		ID int `json:"ID"`
+		ID    int    `json:"ID"`
+		Token string `json:"Token"`
 	}
 
 	json.Unmarshal(reqBody, &req)
@@ -127,12 +128,25 @@ func getDeckReq(w http.ResponseWriter, r *http.Request) {
 
 	err = collection.FindOne(ctx, bson.D{{Key: "id", Value: req.ID}}).Decode(&deck)
 	if err != nil {
-
 		// TODO: There has gotta be a better way to do this haha
 		// Maybe send a 404 response?
 		json.NewEncoder(w).Encode(Deck{-1, "Deck does not exist.", []Card{{"Card Not found", ":("}}, true, ""})
-
 		return
+	}
+
+	/* If deck is private check the token */
+	if !deck.IsPublic {
+		tokenInfo, err := VerifyIdToken(req.Token)
+		if err != nil {
+			/* Bad Token => Unauthorized */
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		if tokenInfo.UserId != deck.Owner {
+			/* Not owner, ergo forbidden */
+			w.WriteHeader(http.StatusForbidden)
+			return
+		}
 	}
 
 	fmt.Println("Got a request for card: ", req.ID)

--- a/frontend/flashfolio/src/Calls.js
+++ b/frontend/flashfolio/src/Calls.js
@@ -10,13 +10,13 @@ getDeck(id: int)
 
 wrapper for getDeck/ call
 */
-export async function getDeck(deckID) {
+export async function getDeck(deckID, token="") {
 	
 	/* Set up and send req to get deck from backend */
 	let reqOpt = {
 		method: "POST",
 		headers: {"Content-Type": "application/json"},
-		body: JSON.stringify({'ID': Number(deckID)}),
+		body: JSON.stringify({'ID': Number(deckID), "Token":token}),
 	}
 
 	/* Send the Request */

--- a/frontend/flashfolio/src/Viewer.js
+++ b/frontend/flashfolio/src/Viewer.js
@@ -37,6 +37,12 @@ export default function Viewer({ viewMode = "view" }) {
 
 	const [deckOwner, setDeckOwner] = useState(null);
 
+	const [isPrivate, setIsPrivate] = useState(false);
+	const handlePrivacyChange = () => {
+		setIsPrivate(!isPrivate);
+		flashdeck.current.IsPublic = isPrivate;
+	}
+
 	function flipView(){
 		if(viewMode==="view")
 			history.replace("/edit/"+deckId);
@@ -100,12 +106,14 @@ export default function Viewer({ viewMode = "view" }) {
 	}
 
 	useEffect(async () => {
-		let deck = await getDeck(Number(deckId));
+		let deck = await getDeck(Number(deckId), loginState !== null ? loginState.tokenId : "");
 		flashdeck.current = deck;
 		setFlashcard(flashdeck.current.Cards[0]);
 		let owner = await getUser(flashdeck.current.Owner);
 		setDeckOwner(owner);
-	}, [deckId]);
+		/* Set Privacy toggle to match deck info */
+		setIsPrivate(!flashdeck.current.IsPublic);
+	}, [deckId, loginState]);
 
 	useEffect(() => {
 		if (isInitialMount.current) {
@@ -211,6 +219,12 @@ export default function Viewer({ viewMode = "view" }) {
 					<br/>
 					<img src={deckOwner === null ? "" : deckOwner.ProfilePicture} />
 					{deckOwner === null ? "" : deckOwner.NickName}
+					{viewMode == "edit" &&
+						<>
+						<br/>
+						Private Deck? <input type="checkbox" checked={isPrivate} onChange={handlePrivacyChange} />
+						</>
+					}
 					<br/>
 					Deck# {flashdeck.current.ID}
 				</div>


### PR DESCRIPTION
Allows  a user to set a deck to private and vice versa -- prevents anyone other than the user from viewing the deck.

1. Implements a private deck toggle under the info section when editing a deck.
2. implements token checking on the back end when trying to access a private deck.

The privacy option is hidden under the deck info tab when editing.

closes #54