### PR TITLE
impl:Delete cards and Iterate backwards

### DIFF
--- a/frontend/flashfolio/package-lock.json
+++ b/frontend/flashfolio/package-lock.json
@@ -4189,9 +4189,9 @@
       }
     },
     "node_modules/ansi-regex": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "engines": {
         "node": ">=8"
       }
@@ -13868,9 +13868,9 @@
       }
     },
     "node_modules/nth-check": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.0.0.tgz",
-      "integrity": "sha512-i4sc/Kj8htBrAiH1viZ0TgU8Y5XqCaV/FziYK6TBczxmeKm3AEFWqqF3195yKudrarqy7Zu80Ra5dobFjn9X/Q==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.0.1.tgz",
+      "integrity": "sha512-it1vE95zF6dTT9lBsYbxvqh0Soy4SPowchj0UBGj/V6cTPnXXtQOPUbhZ6CmGzAD/rW22LQK6E96pcdJXk4A4w==",
       "dependencies": {
         "boolbase": "^1.0.0"
       },
@@ -19335,9 +19335,9 @@
       "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
     },
     "node_modules/tmpl": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
-      "integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE="
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
+      "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw=="
     },
     "node_modules/to-arraybuffer": {
       "version": "1.0.1",
@@ -24811,9 +24811,9 @@
       "integrity": "sha1-gTWEAhliqenm/QOflA0S9WynhZ4="
     },
     "ansi-regex": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
     },
     "ansi-styles": {
       "version": "3.2.1",
@@ -32234,9 +32234,9 @@
       }
     },
     "nth-check": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.0.0.tgz",
-      "integrity": "sha512-i4sc/Kj8htBrAiH1viZ0TgU8Y5XqCaV/FziYK6TBczxmeKm3AEFWqqF3195yKudrarqy7Zu80Ra5dobFjn9X/Q==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.0.1.tgz",
+      "integrity": "sha512-it1vE95zF6dTT9lBsYbxvqh0Soy4SPowchj0UBGj/V6cTPnXXtQOPUbhZ6CmGzAD/rW22LQK6E96pcdJXk4A4w==",
       "requires": {
         "boolbase": "^1.0.0"
       }
@@ -36566,9 +36566,9 @@
       "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
     },
     "tmpl": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
-      "integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE="
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
+      "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw=="
     },
     "to-arraybuffer": {
       "version": "1.0.1",

--- a/frontend/flashfolio/src/Flashcard.js
+++ b/frontend/flashfolio/src/Flashcard.js
@@ -66,33 +66,20 @@ export default function Flashcard({flashcard, editMode=false, flashdeck}) {
 	}, [flashcard]);
 
 	function deleteCard() {
-		//change flashdeck to state not reference
-		
-		/* if there's 1 card, then make an empty card
+		/* if there's one card, make a blank card */
 		if (flashdeck.Cards.length === 1) {
 			flashdeck.Cards[0] = {};
 			flashdeck.Cards[0].FrontSide = "";
 			flashdeck.Cards[0].BackSide = "";
-			/* view the blank card 
-			setFlashcard(flashdeck.Cards[cardIterator]);
-			
 			return;
 		}
-		*/
 
 		/* delete the card */
 		var index = flashdeck.Cards.indexOf(flashcard);
 		delete flashdeck.Cards[index];
 
-		/* update Cards removing the null pointer */
+		/* update Cards list by removing the null pointer */
 		flashdeck.Cards = flashdeck.Cards.filter(function () { return true; });
-
-		/* update view 
-		flashdeck.Cards.map(fc => {
-			return <div><Flashcard flashcard={fc} editMode={editMode} flashdeck={flashdeck} /></div>
-		});
-		*/
-		//cardContents();
 		}
 
 	return (

--- a/frontend/flashfolio/src/Flashcard.js
+++ b/frontend/flashfolio/src/Flashcard.js
@@ -1,19 +1,22 @@
-import React, {useState, useRef, useEffect} from 'react'
+import React, {useState, useRef, useEffect, useContext } from 'react'
 import './Flashcard.css'
 
-export default function Flashcard({flashcard, editMode=false, flashdeck}) {
+
+export default function Flashcard({flashcard, editMode=false, delfunc}) {
 
 	const [flip, setFlip] = useState(false);
 	const [showEditor, setShowEditor] = useState(false);	
 
 	/* Returns appropriate side according to flip state */
-	const currentSide = () => flip ? flashcard.BackSide : flashcard.FrontSide;
+	const currentSide = () => flip ? cardState.BackSide : cardState.FrontSide;
 
 	/* Ref for the actual textarea (maybe can be removed?)*/
 	const editor = useRef(null);
 
 	/* State for the editor textarea's value */
 	const [editVal, setEditVal] = useState("");
+
+	const [cardState, setCardState] = useState(flashcard);
 
 	/* Executed when editor textarea is changed by user */
 	const updateCard = () => {
@@ -63,24 +66,10 @@ export default function Flashcard({flashcard, editMode=false, flashdeck}) {
 	/* If the flashcard changes to a different one, update the editor */
 	useEffect(() => {
 		setEditVal(currentSide());
+		setCardState(flashcard);
 	}, [flashcard]);
 
-	function deleteCard() {
-		/* if there's one card, make a blank card */
-		if (flashdeck.Cards.length === 1) {
-			flashdeck.Cards[0] = {};
-			flashdeck.Cards[0].FrontSide = "";
-			flashdeck.Cards[0].BackSide = "";
-			return;
-		}
-
-		/* delete the card */
-		var index = flashdeck.Cards.indexOf(flashcard);
-		delete flashdeck.Cards[index];
-
-		/* update Cards list by removing the null pointer */
-		flashdeck.Cards = flashdeck.Cards.filter(function () { return true; });
-		}
+	const deleteCard = () => delfunc(flashcard);
 
 	return (
 		<div>

--- a/frontend/flashfolio/src/Flashcard.js
+++ b/frontend/flashfolio/src/Flashcard.js
@@ -80,9 +80,10 @@ export default function Flashcard({flashcard, editMode=false, delfunc}) {
 		<button onClick={flipCard}>
 			Flip
 		</button>
-		<button onClick={deleteCard}>
-			Delete
-		</button>
+		{editMode ? 
+			<button onClick={deleteCard}>
+				Delete
+			</button>:""}
 		<div data-testid = "card" onClick={cardClick} class="card">
 			{cardContents()}
 		</div>

--- a/frontend/flashfolio/src/Flashcard.js
+++ b/frontend/flashfolio/src/Flashcard.js
@@ -1,7 +1,7 @@
 import React, {useState, useRef, useEffect} from 'react'
 import './Flashcard.css'
 
-export default function Flashcard({flashcard, editMode=false}) {
+export default function Flashcard({flashcard, editMode=false, flashdeck}) {
 
 	const [flip, setFlip] = useState(false);
 	const [showEditor, setShowEditor] = useState(false);	
@@ -65,6 +65,34 @@ export default function Flashcard({flashcard, editMode=false}) {
 		setEditVal(currentSide());
 	}, [flashcard]);
 
+	function deleteCard() {
+		/* if there's 1 card, then make an empty card
+		if (flashdeck.current.Cards.length === 1) {
+			flashdeck.current.Cards[0] = {};
+			flashdeck.current.Cards[0].FrontSide = "";
+			flashdeck.current.Cards[0].BackSide = "";
+			/* view the blank card 
+			setFlashcard(flashdeck.current.Cards[cardIterator]);
+			
+			return;
+		}
+		*/
+
+		/* delete the card */
+		var index = flashdeck.current.Cards.indexOf(flashcard);
+		delete flashdeck.current.Cards[index];
+
+		/* update Cards removing the null pointer */
+		flashdeck.current.Cards = flashdeck.current.Cards.filter(function () { return true; });
+
+		/* update view */
+		flashdeck.current.Cards.map(fc => {
+			return <div><Flashcard flashcard={fc} editMode={editMode} flashdeck={flashdeck} /></div>
+		});
+		
+		//cardContents();
+		}
+
 	return (
 		<div>
 		{editMode ? 
@@ -73,6 +101,9 @@ export default function Flashcard({flashcard, editMode=false}) {
 			</button>:""}
 		<button onClick={flipCard}>
 			Flip
+		</button>
+		<button onClick={deleteCard}>
+			Delete
 		</button>
 		<div data-testid = "card" onClick={cardClick} class="card">
 			{cardContents()}

--- a/frontend/flashfolio/src/Flashcard.js
+++ b/frontend/flashfolio/src/Flashcard.js
@@ -66,30 +66,32 @@ export default function Flashcard({flashcard, editMode=false, flashdeck}) {
 	}, [flashcard]);
 
 	function deleteCard() {
+		//change flashdeck to state not reference
+		
 		/* if there's 1 card, then make an empty card
-		if (flashdeck.current.Cards.length === 1) {
-			flashdeck.current.Cards[0] = {};
-			flashdeck.current.Cards[0].FrontSide = "";
-			flashdeck.current.Cards[0].BackSide = "";
+		if (flashdeck.Cards.length === 1) {
+			flashdeck.Cards[0] = {};
+			flashdeck.Cards[0].FrontSide = "";
+			flashdeck.Cards[0].BackSide = "";
 			/* view the blank card 
-			setFlashcard(flashdeck.current.Cards[cardIterator]);
+			setFlashcard(flashdeck.Cards[cardIterator]);
 			
 			return;
 		}
 		*/
 
 		/* delete the card */
-		var index = flashdeck.current.Cards.indexOf(flashcard);
-		delete flashdeck.current.Cards[index];
+		var index = flashdeck.Cards.indexOf(flashcard);
+		delete flashdeck.Cards[index];
 
 		/* update Cards removing the null pointer */
-		flashdeck.current.Cards = flashdeck.current.Cards.filter(function () { return true; });
+		flashdeck.Cards = flashdeck.Cards.filter(function () { return true; });
 
-		/* update view */
-		flashdeck.current.Cards.map(fc => {
+		/* update view 
+		flashdeck.Cards.map(fc => {
 			return <div><Flashcard flashcard={fc} editMode={editMode} flashdeck={flashdeck} /></div>
 		});
-		
+		*/
 		//cardContents();
 		}
 

--- a/frontend/flashfolio/src/Viewer.js
+++ b/frontend/flashfolio/src/Viewer.js
@@ -77,13 +77,13 @@ export default function Viewer({ viewMode = "view" }) {
 			return (
 				<div class="flash-grid">
 					{flashdeck.current.Cards.map(fc => {
-						return <div><Flashcard flashcard={fc} editMode={viewMode == "edit"} flashdeck={flashdeck} /></div>
+						return <div><Flashcard flashcard={fc} editMode={viewMode === "edit"} flashdeck={flashdeck} /></div>
 					})}
 				</div>
 			)
 		}
 		return (
-			<Flashcard flashcard={flashcard} editMode={viewMode == "edit"} flashdeck={flashdeck} />
+			<Flashcard flashcard={flashcard} editMode={viewMode === "edit"} flashdeck={flashdeck} />
 		)
 	}
 
@@ -117,32 +117,13 @@ export default function Viewer({ viewMode = "view" }) {
 		setFlashcard(flashdeck.current.Cards[cardIterator]);
 	}
 
-	function deleteCard() {
-		/* if there's 1 card, then make an empty card*/
-		if (flashdeck.current.Cards.length === 1) {
-			flashdeck.current.Cards[0] = {};
-			flashdeck.current.Cards[0].FrontSide = "";
-			flashdeck.current.Cards[0].BackSide = "";
-			/* view the blank card */
-			setFlashcard(flashdeck.current.Cards[cardIterator]);
-			return;
-		}
-
-		/* delete the card */
-		delete flashdeck.current.Cards[cardIterator];
-
-		/* update Cards removing the null pointer */
-		flashdeck.current.Cards = flashdeck.current.Cards.filter(function () { return true; });
-
-		/* update view to the next card or cycle to beginning if deleting the last card */
-		if (cardIterator < flashdeck.current.Cards.length) {
-			setFlashcard(flashdeck.current.Cards[cardIterator])
+	function previousCard() {
+		if (cardIterator===0) {
+			setCardIterator(flashdeck.current.Cards.length - 1);
 		} else {
-			setCardIterator(0);
-			setFlashcard(flashdeck.current.Cards[0]);
+			setCardIterator(cardIterator - 1);
 		}
 	}
-
 	const loadButton = () => {
 		history.push("/load");
 	};
@@ -156,26 +137,27 @@ export default function Viewer({ viewMode = "view" }) {
 			Title: {flashdeck.current.Title}
 			DeckId: {deckId}
 			<br />
-			<button onClick = {flipView}> {viewMode == "edit" ? "View Deck" : "Edit Deck"} </button>
-			{viewMode == "edit" && <button onClick={changeLayout}>Change Layout</button>}
+			<button onClick = {flipView}> {viewMode === "edit" ? "View Deck" : "Edit Deck"} </button>
+			{viewMode === "edit" && <button onClick={changeLayout}>Change Layout</button>}
 			{tileLayout()}
+			{!tileCards && <button
+				onClick={previousCard}
+			>Previous Card</button>}
 			{!tileCards && <button
 				onClick={() => setCardIterator(cardIterator + 1)}
 			>Next Card</button>}
-			{viewMode == "view" && (hidden ?
+			{viewMode === "view" && (hidden ?
 				<button id="shuf" onClick={() => shufFunction()}>Shuffle</button> :
 				<button id="unshuf" onClick={() => shufOn ? unshufFunction() : null}>Unshuffle</button>)
 			}
 			{viewMode === "edit" && <button onClick = {addCard}>Add a card</button>}
-			{viewMode === "edit" && <button onClick={deleteCard}>
-				Delete</button>}
 			<a
 				href={`data:text/json;charset=utf-8,${encodeURIComponent(
 					JSON.stringify(flashdeck.current, null, '\t')
 				)}`}
 				download="myDeck.json"
 			>Download</a>
-			{viewMode == "edit" && <button onClick={saveChanges}>Save Changes</button>}
+			{viewMode === "edit" && <button onClick={saveChanges}>Save Changes</button>}
 			<button onClick={homeButton}>Home</button>
 			<button onClick={loadButton}>Load Deck</button>
 		</div>

--- a/frontend/flashfolio/src/Viewer.js
+++ b/frontend/flashfolio/src/Viewer.js
@@ -15,6 +15,7 @@ Displays a single card at a time to the screen.
 */
 var shufOrder = [];
 var hidden = true;
+
 export default function Viewer({ viewMode = "view" }) {
 	const history = useHistory();
 
@@ -76,13 +77,13 @@ export default function Viewer({ viewMode = "view" }) {
 			return (
 				<div class="flash-grid">
 					{flashdeck.Cards.map(fc => {
-						return <div><Flashcard flashcard={fc} editMode={viewMode === "edit"} flashdeck={flashdeck} /></div>
+						return <div><Flashcard flashcard={fc} editMode={viewMode === "edit"} delfunc={deleteCard}/></div>
 					})}
 				</div>
 			)
 		}
 		return (
-			<Flashcard flashcard={flashcard} editMode={viewMode === "edit"} flashdeck={flashdeck} />
+			<Flashcard flashcard={flashcard} editMode={viewMode === "edit"} delfunc={deleteCard}/>
 		)
 	}
 
@@ -119,6 +120,31 @@ export default function Viewer({ viewMode = "view" }) {
 		flashdeck.Cards[flashdeck.Cards.length] = {FrontSide: "", BackSide: ""};
 		setCardIterator(flashdeck.Cards.length-1);
 		setFlashcard(flashdeck.Cards[cardIterator]);
+	}
+
+	function deleteCard(card, clear) {
+		/* Extremely hacky disgusting way of deepcopying */
+		let copy = { ... flashdeck}
+		copy.Cards = flashdeck.Cards
+		/* if there's one card, make a blank card */
+		if (copy.Cards.length === 1) {
+			copy.Cards[0] = {
+				FrontSide: "",
+				BackSide: ""
+			}
+			setFlashcard(copy.Cards[0]);
+			return;
+		}
+
+		/* delete the card */
+		var index = copy.Cards.indexOf(card);
+		delete copy.Cards[index];
+
+		/* update Cards list by removing the null pointer */
+		copy.Cards = copy.Cards.filter(function () { return true; });
+		setFlashdeck(copy)
+		console.log(copy)
+		console.log(flashdeck)
 	}
 
 	function previousCard() {

--- a/frontend/flashfolio/src/Viewer.js
+++ b/frontend/flashfolio/src/Viewer.js
@@ -18,7 +18,7 @@ var hidden = true;
 export default function Viewer({ viewMode = "view" }) {
 	const history = useHistory();
 
-	const flashdeck = useRef("");
+	const [flashdeck, setFlashdeck] = useState("");
 	const isInitialMount = useRef(true);
 
 	const [flashcard, setFlashcard] = useState("");
@@ -43,40 +43,39 @@ export default function Viewer({ viewMode = "view" }) {
 		setCardIterator(0);
 		setShufOn(true);
 		shufOrder = [];
-		while (shufOrder.length < flashdeck.current.Cards.length) {
-			var num = Math.floor(Math.random() * flashdeck.current.Cards.length);
+		while (shufOrder.length < flashdeck.Cards.length) {
+			var num = Math.floor(Math.random() * flashdeck.Cards.length);
 			if (shufOrder.indexOf(num) === -1)
 				shufOrder.push(num);
 		}
 		document.getElementById('shuf').style.visibility = "visible";
-		setFlashcard(flashdeck.current.Cards[shufOrder[cardIterator]]);
+		setFlashcard(flashdeck.Cards[shufOrder[cardIterator]]);
 	}
 
 	function unshufFunction() {
 		hidden = true;
 		setCardIterator(0);
 		setShufOn(false);
-		setFlashcard(flashdeck.current.Cards[cardIterator]);
+		setFlashcard(flashdeck.Cards[cardIterator]);
 	}
 
 	let { deckId } = useParams();
 
 
 	function saveChanges(){
-		console.log(flashdeck.current)
-		saveDeck(flashdeck.current)
+		console.log(flashdeck)
+		saveDeck(flashdeck)
 	}
 
 	function changeLayout() {
 		setTileCards(!tileCards)
 	}
 
-
 	function tileLayout() {
 		if (tileCards) {
 			return (
 				<div class="flash-grid">
-					{flashdeck.current.Cards.map(fc => {
+					{flashdeck.Cards.map(fc => {
 						return <div><Flashcard flashcard={fc} editMode={viewMode === "edit"} flashdeck={flashdeck} /></div>
 					})}
 				</div>
@@ -90,10 +89,14 @@ export default function Viewer({ viewMode = "view" }) {
 	useEffect(() => {
 		getDeck(Number(deckId))
 			.then(deck => {
-				flashdeck.current = deck;
-				setFlashcard(flashdeck.current.Cards[0]);
-			});
+				setFlashdeck(deck);
+			})
 	}, [deckId]);
+
+	/* if flashdeck changes, update flashdeck */
+	useEffect(() => {
+		tileLayout();
+	}, [flashdeck]);
 
 	useEffect(() => {
 		if (isInitialMount.current) {
@@ -101,29 +104,30 @@ export default function Viewer({ viewMode = "view" }) {
 		}
 		else {
 			/* useEffect code here to be run on count update only */
-			if (cardIterator < flashdeck.current.Cards.length) {
+			if (cardIterator < flashdeck.Cards.length) {
 				if ((!shufOn))
-					setFlashcard(flashdeck.current.Cards[cardIterator]);
+					setFlashcard(flashdeck.Cards[cardIterator]);
 				else
-					setFlashcard(flashdeck.current.Cards[shufOrder[cardIterator]]);
+					setFlashcard(flashdeck.Cards[shufOrder[cardIterator]]);
 			}
 			else { setCardIterator(0); }
 		}
 	}, [cardIterator])
 
 	function addCard() {
-		flashdeck.current.Cards[flashdeck.current.Cards.length] = {FrontSide: "", BackSide: ""};
-		setCardIterator(flashdeck.current.Cards.length-1);
-		setFlashcard(flashdeck.current.Cards[cardIterator]);
+		flashdeck.Cards[flashdeck.Cards.length] = {FrontSide: "", BackSide: ""};
+		setCardIterator(flashdeck.Cards.length-1);
+		setFlashcard(flashdeck.Cards[cardIterator]);
 	}
 
 	function previousCard() {
 		if (cardIterator===0) {
-			setCardIterator(flashdeck.current.Cards.length - 1);
+			setCardIterator(flashdeck.Cards.length - 1);
 		} else {
 			setCardIterator(cardIterator - 1);
 		}
 	}
+
 	const loadButton = () => {
 		history.push("/load");
 	};
@@ -134,7 +138,7 @@ export default function Viewer({ viewMode = "view" }) {
 	return (
 		<div>
 			<UserInfoPreview />
-			Title: {flashdeck.current.Title}
+			Title: {flashdeck.Title}
 			DeckId: {deckId}
 			<br />
 			<button onClick = {flipView}> {viewMode === "edit" ? "View Deck" : "Edit Deck"} </button>
@@ -153,7 +157,7 @@ export default function Viewer({ viewMode = "view" }) {
 			{viewMode === "edit" && <button onClick = {addCard}>Add a card</button>}
 			<a
 				href={`data:text/json;charset=utf-8,${encodeURIComponent(
-					JSON.stringify(flashdeck.current, null, '\t')
+					JSON.stringify(flashdeck, null, '\t')
 				)}`}
 				download="myDeck.json"
 			>Download</a>

--- a/frontend/flashfolio/src/Viewer.js
+++ b/frontend/flashfolio/src/Viewer.js
@@ -77,13 +77,13 @@ export default function Viewer({ viewMode = "view" }) {
 			return (
 				<div class="flash-grid">
 					{flashdeck.current.Cards.map(fc => {
-						return <div><Flashcard flashcard={fc} editMode={viewMode == "edit"} /></div>
+						return <div><Flashcard flashcard={fc} editMode={viewMode == "edit"} flashdeck={flashdeck} /></div>
 					})}
 				</div>
 			)
 		}
 		return (
-			<Flashcard flashcard={flashcard} editMode={viewMode == "edit"} />
+			<Flashcard flashcard={flashcard} editMode={viewMode == "edit"} flashdeck={flashdeck} />
 		)
 	}
 

--- a/frontend/flashfolio/src/Viewer.js
+++ b/frontend/flashfolio/src/Viewer.js
@@ -93,9 +93,10 @@ export default function Viewer({ viewMode = "view" }) {
 			})
 	}, [deckId]);
 
-	/* if flashdeck changes, update flashdeck */
+	/* this will display the current card */
 	useEffect(() => {
-		tileLayout();
+		if (!isInitialMount.current)
+			setFlashcard(flashdeck.Cards[cardIterator])
 	}, [flashdeck]);
 
 	useEffect(() => {


### PR DESCRIPTION
Sorry, I've accidentally merged my "previous card" branch into the "delete card" branch so I will close two PBIs in this pull request this time:

There is a previous card button that allows the user to iterate backwards through cards.

Closes issue #57 

Delete cards requires refactoring of the flashdeck constant from reference to state so that the viewer can rerender when cards are deleted. The user can delete any card whether it is on tile view or single card view. 

Deleted card changes appear both on the .json when you download, and dynamically on the viewer as the user deletes them. The delete button only appears when you are in edit view.

Closes issue #50 

