### PR TITLE
impl: Searching for decks

### DIFF
--- a/backend/flashfolio/deck.go
+++ b/backend/flashfolio/deck.go
@@ -307,8 +307,15 @@ func QueryDecksReq(w http.ResponseWriter, r *http.Request) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
+	var query bson.D
+	if req.Query == "" {
+		query = bson.D{{Key: "ispublic", Value: true}}
+	} else {
+		query = bson.D{{Key: "ispublic", Value: true}, {Key:"$text", Value: bson.D{{Key:"$search", Value:req.Query}}}}
+	}
+
 	/* Find the decks */
-	cur, err := DeckCollection.Find(ctx, bson.D{{Key: "ispublic", Value: true}})
+	cur, err := DeckCollection.Find(ctx, query)
 
 	defer cur.Close(ctx)
 	if err != nil {
@@ -324,6 +331,9 @@ func QueryDecksReq(w http.ResponseWriter, r *http.Request) {
 	/* Get the page */
 	for i := 0; i < pageSize; i++ {
 		ret.RemainingDecks = cur.Next(ctx)
+		if !ret.RemainingDecks {
+			break
+		}
 		var deck Deck
 		cur.Decode(&deck)
 		ret.DeckIDs = append(ret.DeckIDs, deck.ID)

--- a/frontend/flashfolio/src/DeckSearch.js
+++ b/frontend/flashfolio/src/DeckSearch.js
@@ -18,13 +18,17 @@ export default function DeckSearch(query, pageNumber, initial = []) {
 		const fetchData = async () => {
 			setLoading(true)
 			let res = await queryDecks(pageNumber, query)
-			setDecks(decks => {
-				return [...new Set([...decks, ...res.DeckIDs])]
-			})
+			console.log("res:", res.DeckIDs)
+			if (res.DeckIDs !== null) {
+				setDecks(decks => {
+					return [...new Set([...decks, ...res.DeckIDs])]
+				})
+			}
 			setHasMore(res.RemainingDecks)
 			setLoading(false)
 		}
 		fetchData()
+		console.log(decks)
 	}, [query, pageNumber])
 
 	return { loading, decks, hasMore }

--- a/frontend/flashfolio/src/Load.js
+++ b/frontend/flashfolio/src/Load.js
@@ -51,17 +51,10 @@ export default function Load() {
 		if (node) observer.current.observe(node)
 	}, [loading, hasMore, pageNumber])
 
-	// function defined but never used 
-	/*
-	function handleSearch(e) {
-		setQuery(e.target.value)
-		setPageNumber(1)
-	}
-	*/
-
 	const updateQuery = () => {
 		console.log(queryField.current.value)
 		setQuery(queryField.current.value)
+		setPageNumber(0)
 	}
 
 	const history = useHistory()
@@ -70,8 +63,10 @@ export default function Load() {
 
 	return (
 		<div>
-			<input type="text" ref={queryField} onChange={updateQuery}/>
-			{loginState !== null && query == "" &&
+			<div>
+				<input type="text" ref={queryField} onChange={updateQuery}/>
+			</div>
+			{loginState !== null && query === "" &&
 				<>
 					<h3>My Decks:</h3><br />
 					<div className="flash-grid">
@@ -82,7 +77,7 @@ export default function Load() {
 				</>}
 			<h3>Public Decks:</h3><br />
 			<div className="flash-grid">
-				{decks.map((deck, index) => {
+				{decks.length === 0 ? "No Decks Found" : decks.map((deck, index) => {
 					if (decks.length === index + 1) {
 						return <div ref={lastDeckElementRef} key={deck} onClick={() => { visit(deck) }}><DeckPreview deckId={deck} /></div>
 					} else {

--- a/frontend/flashfolio/src/Load.js
+++ b/frontend/flashfolio/src/Load.js
@@ -16,9 +16,11 @@ export default function Load() {
 
 	const { loginState } = useContext(loginContext)
 
-	const [query] = useState("") // setQuery was defined but never used
+	const [query, setQuery] = useState("") // setQuery was defined but never used
 	const [pageNumber, setPageNumber] = useState(0)
 	const [myDecks, setMyDecks] = useState([])
+
+	const queryField = useRef("");
 
 	const {
 		decks,
@@ -56,13 +58,20 @@ export default function Load() {
 		setPageNumber(1)
 	}
 	*/
+
+	const updateQuery = () => {
+		console.log(queryField.current.value)
+		setQuery(queryField.current.value)
+	}
+
 	const history = useHistory()
 
 	const visit = (id) => history.push("/view/" + id)
 
 	return (
 		<div>
-			{loginState !== null &&
+			<input type="text" ref={queryField} onChange={updateQuery}/>
+			{loginState !== null && query == "" &&
 				<>
 					<h3>My Decks:</h3><br />
 					<div className="flash-grid">


### PR DESCRIPTION
Allows the user to search for decks on the load page. Deck search is done based off of the title of the deck.

Changes:

1. Adds a search field on the front end that allows the user to enter a query.
2. Added a check to hide the current user's decks if a query is entered.
3. Adds a "Decks not found" message if no deck matches the query
4. Backend now returns an empty deck if there are no more decks to query.
5. Search results are updated as the user changes their query -- no need for a submit button.

to get deck searches to work properly you will have to run the following commands just once in mongosh:
```
use flashfolio
db.decks.createIndex({title:"text"})
```

closes #86 